### PR TITLE
feat: Created offer page like offer page of Mercado Libre

### DIFF
--- a/public/offers.html
+++ b/public/offers.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Ofertas</title>
     <link rel="shortcut icon" href="https://rooftop.dev/images/favicon.png" type="image/x-icon">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -19,12 +19,12 @@
     <header>
 
         <!-- Block: Barra de navegacion -->
-        <div class="row bg-primary">
+        <div class="row padding-none bg-primary">
             <div class="col rounded">
                 <img width="44px" src="https://rooftop.dev/images/favicon.png" alt="logo" >
             </div>
 
-            <div class="row bg-main rounded">
+            <div class="row padding-none bg-main rounded">
                 <div class="col txt-white">
                     <i class="fas fa-search"></i>
                 </div>
@@ -47,118 +47,198 @@
 
         <!-- Block: Barra de domicilio-->
         <div class="row bg-primary">
-            <div class="row txt-white">
-                <i class="fas fa-map-marker-alt"></i>
-                <p>Enviar a Capital Federal</p>
+            <div class="row padding-none txt-white">
+                <div class="col padding-none">
+                    <i class="fas fa-map-marker-alt"></i>
+                </div>
+                <div class="col padding-none">
+                    <p>Enviar a Capital Federal</p>
+                </div>
             </div>
-            <i class="fas fa-angle-right txt-white"></i>
+            <div class="col padding-none">
+                <i class="fas fa-angle-right txt-white"></i>
+            </div>
         </div>
     </header>
     <main class="bg-main">
-        <div class="row shadow-sm ">
-            <p>10.000 productos</p>
-            <div class="row"></div>
-            <div class="row link-color">
-                <p>Filtrar</p>
-                <i class="fas fa-angle-right"></i>
+        <div class="row shadow-sm">
+            <div class="row">
+                <div class="col padding-none">
+                    <p>10.000 productos</p>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col padding-none link-color">
+                    <p>Filtrar</p>
+                </div>
+                <div class="col padding-none link-color">
+                    <i class="fas fa-angle-right"></i>
+                </div>
             </div>
         </div>
 
         <!-- Block: Carousel de lista de ofertas -->
         <div class="row">
             <div class="col shadow-sm rounded active ">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="">
-                <p class="txt-bold">Todas las ofertas</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="">
+                </div>
+                <div class="col">
+                    <p class="txt-bold txt-center">Todas las ofertas</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Ofertas relámpago</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Ofertas relámpago</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Especial Electro</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Especial Electro</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Supermecado</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Supermecado</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Notebooks</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Notebooks</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Menos de $2000</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Menos de $2000</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Celulares</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Celulares</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Todas las ofertas</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Ofertas Grandes</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Ofertas Grandes</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Especial Pymes</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Especial Pymes</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Herramientas</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Herramientas</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Zapatillas</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Zapatillas</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Auriculares</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Auriculares</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Televisiones</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Televisiones</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Bicicletas</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Bicicletas</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Colchones</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Colchones</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Parlates</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Parlates</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Calefacción</p>
+                </div>
             </div>
 
             <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Calefacción</p>
-            </div>
-
-            <div class="col shadow-sm rounded">
-                <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
-                <p>Videojuegos</p>
+                <div class="col">
+                    <img width="48px" height="48px" src="https://http2.mlstatic.com/storage/splinter-admin/o:f_webp,q_auto:low/1583341146061-todas-las-ofertas@3x.png" alt="icono oferta">
+                </div>
+                <div class="col">
+                    <p class="txt-center">Videojuegos</p>
+                </div>
             </div>
         </div>
 
@@ -171,12 +251,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -184,12 +264,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -197,12 +277,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -210,12 +290,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -223,12 +303,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -236,12 +316,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -249,12 +329,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -262,12 +342,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -275,12 +355,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -288,12 +368,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -301,12 +381,12 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
                 <li class="col grey-border">
                     <img width="144px" height="144px" src="https://http2.mlstatic.com/D_Q_NP_2X_715512-MLA46711394228_072021-T.webp" alt="celular">
@@ -314,30 +394,48 @@
                         <span class="txt-white">OFERTA DEL DÍA</span>
                     </div>
                     <p class="txt-grey">
-                        <del>$ 20.999</del>
+                        <span class="txt-strike">$ 20.999</span>
                     </p>
                     <p>$ 18.999 <span class="txt-green">9% OFF</span></p>
                     <p class="txt-bold txt-green">Envio gratis</p>
                     <p>Nokia 24 M 64 Gb Carbón 3 Gb Ram</p>
-                    <p class="txt-grey">por Mercado Libre Electronica</p>
+                    <p class="txt-light-grey">por Mercado Libre Electronica</p>
                 </li>
             </ul>
         </div>
         <!-- Component: TextPaginator & PageNumberPaginator -->
         <div class="row">
             <ul class="row">
-                <li class="row txt-grey"><i class="fas fa-angle-right"></i><p>Anterior</p></li>
+                <li class="row txt-grey">
+                    <div class="col">
+                        <i class="fas fa-angle-right"></i>
+                    </div>
+                    <div class="col">
+                        <p>Anterior</p>
+                    </div>
+                </li>
                 <li class="col bg-light-grey">1</li>
-                <li class="row txt-grey"><p>Siguiente</p><i class="fas fa-angle-right"></i></li>
-            </div>
+                <li class="row txt-grey">
+                    <div class="col">
+                        <p>Siguiente</p>
+                    </div>
+                    <div class="col">
+                        <i class="fas fa-angle-right"></i>
+                    </div>
+                </li>
+            </ul>
         </div>
         <!-- Component: Dercargar App -->
         <div class="row bg-primary grey-border">
             <div class="row">
-                <div class="bg-primary shadow-sm">
-                    <img width="44px" src="https://rooftop.dev/images/favicon.png" alt="logo">
+                <div class="col">
+                    <div class="bg-primary shadow-sm">
+                        <img width="44px" src="https://rooftop.dev/images/favicon.png" alt="logo">
+                    </div>
                 </div>
-                <p class="txt-white">¡Comprá y vendé con la app!</p>
+                <div class="col">
+                    <p class="txt-white">¡Comprá y vendé con la app!</p>
+                </div>
             </div>
         </div>
 
@@ -362,8 +460,12 @@
 
             <div class="row">
                 <div class="row">
-                    <a class="link" href="#">Ingresá</a>
-                    <a class="link" href="#">Creá tu cuenta</a>
+                    <div class="col">
+                        <a class="link" href="#">Ingresá</a>
+                    </div>
+                    <div class="col">
+                        <a class="link" href="#">Creá tu cuenta</a>
+                    </div>
                 </div>
             </div>
 
@@ -377,9 +479,13 @@
             </div>
 
             <div class="row">
-                <div class="col">
-                    <div class="row"><p class="txt-grey">© 1999-2021 MercadoLibre S.R.L.</p></div>
-                    <div class="row"><p class="txt-grey">Av. Caseros 3039, Piso 2, CP 1264, Parque Patricios, CABA</p></div>
+                <div class="col padding-none">
+                    <div class="col">
+                        <p class="txt-grey">© 1999-2021 MercadoLibre S.R.L.</p>
+                    </div>
+                    <div class="col">
+                        <p class="txt-grey">Av. Caseros 3039, Piso 2, CP 1264, Parque Patricios, CABA</p>
+                    </div>
                 </div>
             </div>
         </footer>


### PR DESCRIPTION
## Creada la página de ofertas parecida a la página de ofertas de Mercado Libre

## Issue: #49

## 📝  Resumen

#### Añadido el archivo `offers.html` en la carpeta `public/`
  - Añadido favicon a través de la url: `https://rooftop.dev/images/favicon.png`
  - Añadido el bloque: `Barra de navegacion`.
  - Añadido el bloque: `Barra de domicilio`.
  - Añadido el bloque: `Carousel de lista de ofertas`
  - Añadido el bloque: `Containter de publicaciones en ofertas`
  - Añadido el componente: `TextPaginator` y `PageNumberPaginator`
  - Añadido el componente: `Dercargar App`
  - Añadido el componente: `Link`
  
 Se puede acceder a traves de: http://localhost:8080/offers.html
## 📷 Screenshots

![Screenshot from 2021-11-03 13-04-34](https://user-images.githubusercontent.com/78811265/140100774-83ee49e1-b9b1-40d8-ad8b-5e0ac004af28.png)

![Screenshot from 2021-11-03 13-04-55](https://user-images.githubusercontent.com/78811265/140100795-f09d5e42-c41b-4500-9af3-c207d8436a82.png)

![Screenshot from 2021-11-03 13-05-23](https://user-images.githubusercontent.com/78811265/140100814-80c99648-174b-4e15-85b6-2b3769aabe0d.png)

