### PR TITLE
Quit padding

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -48,6 +48,9 @@ p::after {
 .col {
     padding: var(--padding-base);
 }
+.padding-none{
+    padding: 0;
+}
 
 .burger-btn {
     height: 2rem;


### PR DESCRIPTION
# Title Quitar padding base de un contenedor

## Issue: #59 

## :memo: Resumen o Descripción: Se agrego la clase .padding-none con la propiedad padding: 0, para quitar padding base. Está declarada luego de las clases row y column como fue requerido. 

## :camera: Screenshot
![Captura](https://user-images.githubusercontent.com/84633047/140395159-62c1c434-7685-47dd-9064-83443776148e.PNG)
s: