### PR TITLE
imagenes por defecto 100% ancho de su contenedor

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -27,6 +27,10 @@ input {
   font-family: 'Poppins', sans-serif;
 }
 
+img{
+  width: 100%;
+}
+
 p::after {
   content: '\a';
   white-space: pre;


### PR DESCRIPTION
# Imágenes por defecto 100% del ancho de su contenedor

## Issue: #104 

## :memo: Resumen o Descripción: Se agrega propiedad a la etiqueta `<img>` para que midan por defecto el 100% de ancho de su contenedor

## :camera: Screenshots:
![image](https://user-images.githubusercontent.com/84633047/142045277-fbfcf250-87c4-4cb2-a619-a694f78ecb1d.png)
