### PR TITLE
Feature 111 margin and padding standards

### DIFF
--- a/src/styles/_margin-and-padding.scss
+++ b/src/styles/_margin-and-padding.scss
@@ -7,7 +7,7 @@ $base-sizes: (
   3: calc($base * 3),
   4: calc($base * 4),
   5: calc($base * 5),
-  6: calc($base * 2)
+  6: calc($base * 6)
 );
 
 /* Margins */

--- a/src/styles/_margin-and-padding.scss
+++ b/src/styles/_margin-and-padding.scss
@@ -1,0 +1,123 @@
+$base: 6px;
+
+$base-sizes: (
+  none: 0,
+  1: $base,
+  2: calc($base * 2),
+  3: calc($base * 3),
+  4: calc($base * 4),
+  5: calc($base * 5),
+  6: calc($base * 2)
+);
+
+/* Margins */
+
+@each $size, $value in $base-sizes {
+  .m-#{$size} {
+    margin: $value;
+  }
+}
+
+/* Horizontal Margins */
+
+@each $size, $value in $base-sizes {
+  .mx-#{$size} {
+    margin: 0 $value;
+  }
+}
+
+/* Vertical Margins */
+
+@each $size, $value in $base-sizes {
+  .my-#{$size} {
+    margin: $value 0;
+  }
+}
+
+/* Top Margins */
+
+@each $size, $value in $base-sizes {
+  .mt-#{$size} {
+    margin-top: $value;
+  }
+}
+
+/* Bottom Margins */
+
+@each $size, $value in $base-sizes {
+  .mb-#{$size} {
+    margin-bottom: $value;
+  }
+}
+
+/* Left Margins */
+
+@each $size, $value in $base-sizes {
+  .ml-#{$size} {
+    margin-left: $value;
+  }
+}
+
+/* Right Margins */
+
+@each $size, $value in $base-sizes {
+  .mr-#{$size} {
+    margin-right: $value;
+  }
+}
+
+/* Paddings */
+
+@each $size, $value in $base-sizes {
+  .p-#{$size} {
+    padding: $value;
+  }
+}
+
+/* Horizontal Paddings */
+
+@each $size, $value in $base-sizes {
+  .px-#{$size} {
+    padding: 0 $value;
+  }
+}
+
+/* Vertical Paddings */
+
+@each $size, $value in $base-sizes {
+  .py-#{$size} {
+    padding: $value 0;
+  }
+}
+
+/* Top Paddings */
+
+@each $size, $value in $base-sizes {
+  .pt-#{$size} {
+    margin-top: $value;
+  }
+}
+
+/* Bottom Paddings */
+
+@each $size, $value in $base-sizes {
+  .pb-#{$size} {
+    margin-bottom: $value;
+  }
+}
+
+/* Left Paddings */
+
+@each $size, $value in $base-sizes {
+  .pl-#{$size} {
+    margin-left: $value;
+  }
+}
+
+/* Right Paddings */
+
+@each $size, $value in $base-sizes {
+  .pr-#{$size} {
+    margin-right: $value;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -2,4 +2,5 @@
 @use "structure";
 @use "flex";
 @use "element-colors";
-@use "hamburger"
+@use "hamburger";
+@use "margins-and-paddings"


### PR DESCRIPTION
# Title
Add margin and padding standards

## Issue: #111 

## :memo: Resumen o Descripción:
Se agregaron loops para las clases de margin y padding con una base de 6px, cada número al final de la clase representa el número por el que se multiplica esta base. Existen las siguientes medidas:

- none,
- 1
- 2
- 3
- 4
- 5
- 6

Así mismo, se crearon clases para cada uno de los márgenes y paddings posibles:

- m, p _(al rededor de todo el elemento)_
- my, py _(vertical)_
- mx, px _(horizontal)_
- mt, pt _(top)_
- mb, pb _(bottom)_
- ml, pl _(left)_
- mr, pr _(right)_