### PR TITLE
Feature 136 create class of flex

### DIFF
--- a/src/styles/_flex.scss
+++ b/src/styles/_flex.scss
@@ -1,0 +1,63 @@
+$flex-basic: (
+    start: flex-start,
+    end: flex-end,
+    center: center,
+);
+
+$flex-space: (
+    around: space-around,
+    between: space-between,
+    evenly: space-evenly,
+);
+
+$flex-specific: (
+    baseline: baseline,
+    stretch: stretch
+);
+
+
+@each $name, $value in $flex-basic {
+    .jc-#{$name} {
+      justify-content: $value;
+    }
+
+    .ai-#{$name} {
+        align-items: $value;
+    }
+
+    .ac-#{$name} {
+        align-content: $value;
+    }
+
+    .as-#{$name} {
+        align-self: $value;
+    }
+}
+
+@each $name, $value in $flex-space {
+    .jc-#{$name} {
+        justify-content: $value;
+    }
+
+    .ac-#{$name} {
+        align-content: $value;
+    }
+}
+
+@each $name, $value in $flex-specific {
+    .ai-#{$name} {
+        align-items: $value;
+    }
+
+    .ac-#{$name} {
+        align-content: $value;
+    }
+
+    .as-#{$name} {
+        align-self: $value;
+    }
+}
+
+.grow-1 {
+    flex-grow: 1;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -2,6 +2,6 @@
 @import "structure";
 @import "flex";
 @import "element-colors";
-@import "hamburger"
+@import "hamburger";
 @use "margins-and-paddings"
 


### PR DESCRIPTION
# Se creó la clases de flex

## Issue: #136 

## :memo: Resumen o Descripción:
Se crearon las siguientes clases:

`justify-content: flex-start` como `.jc-start`
`justify-content: flex-end` como `.jc-end`
`justify-content: center` como `.jc-center`
`justify-content: space-around` como `.jc-around`
`justify-content: space-between` como `.jc-between`
`justify-content: space-evenly` como `.jc-evenly`

`align-items: flex-start` como `.ai-start`
`align-items: flex-end` como `.ai-end`
`align-items: center` como `.ai-center`
`align-items: baseline` como `.ai-baseline`
`align-items: stretch` como `.ai-stretch`

`align-content: flex-start` como `.ac-start`
`align-content: flex-end` como `.ac-end`
`align-content: center` como `.ac-center`
`align-content: space-around` como `.ac-around`
`align-content: space-between` como `.ac-between`
`align-content: space-evently` como `.ac-evently`
`align-content: baseline` como `.ac-baseline`
`align-content: stretch` como `.ac-stretch`

`align-self: flex-start` como `.as-start`
`align-self: flex-end` como `.as-end`
`align-self: center` como `.as-center`
`align-self: baseline` como `.as-baseline`
`align-self: stretch` como `.as-stretch`

`flex-grow: 1` como `.grow-1`

## :camera: Screenshots: