### PR TITLE
Feature 141 142 hamburger menu

### DIFF
--- a/src/styles/_hamburger.scss
+++ b/src/styles/_hamburger.scss
@@ -1,17 +1,15 @@
 .burger-btn {
   height: 2rem;
   width: 2rem;
-  border: 1px solid black;
   display: flex;
   justify-content: center;
   align-items: center;
   cursor: pointer;
-  border-radius: .5rem;
 }
 
-.burger-icon {
+.burger {
   position: relative;
-  width: .75rem;
+  width: 20px;
   height: 2px;
   background-color: black;
   border-radius: 5px;
@@ -19,7 +17,7 @@
   &::after{
     content: '';
     position: absolute;
-    width: .75rem;
+    width: 20px;
     height: 2px;
     background-color: black;
     border-radius: 5px;
@@ -34,7 +32,7 @@
 }
 
 /* ANIMATION */
-#burger-btn-check:checked+.burger-btn>.burger-icon {
+#burger-btn-check:checked+.burger-btn>.burger {
   background: transparent;
   box-shadow: none;
   &::before,

--- a/src/styles/_hamburger.scss
+++ b/src/styles/_hamburger.scss
@@ -1,6 +1,6 @@
 .burger-btn {
-  height: 2rem;
-  width: 2rem;
+  height: 30px;
+  width: 30px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -24,10 +24,10 @@
     transition: all .5s ease-in-out;
   }
   &::before {
-    transform: translateY(-.4rem);
+    transform: translateY(-6px);
   }
   &::after {
-    transform: translateY(.4rem);
+    transform: translateY(6px);
   }
 }
 


### PR DESCRIPTION
# Modificaciones al menú hamburguesa

## Issue: #141 y #142

## :memo: Resumen o Descripción:

- [x]  Cambiar el ancho de las líneas del menú hamburguesa
- [x] Cambiar el ancho del contenedor del menú hamburguesa
- [x] Remover el borde externo del menú hamburguesa
- [x] Remover color por defecto (se debe usar el loop del issue #139 )

para utilizar los colores disponibles se debe usar `burger-#{color}`, ejemplo: `burger-orange`


- orange
- primary-lighter
- primary-light
- primary
- primary-dark
- black-95
- black-80
- black-45
- black-40
- black-20
- light
- lightest-grey
- lighter-grey
- light-background-grey
- background-grey
- light-grey
- grey
- dark-grey
- darker-grey
- lighter-blue
- light-blue
- blue
- success
- benefit
- light-green
- transparent

## :camera: Screenshots:
![image](https://user-images.githubusercontent.com/69699380/146582333-5367dff2-8966-4ccf-b6f0-3743bfeef43c.png)
![image](https://user-images.githubusercontent.com/69699380/146582355-30f05d29-c737-43d0-8514-722edeb68ea9.png)

